### PR TITLE
feat: [#358] Remove driver.Schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/Masterminds/squirrel v1.5.4
-	github.com/goravel/framework v1.15.2-0.20250309082515-9a7bcbec1a43
+	github.com/goravel/framework v1.15.2-0.20250309092812-0d45fdd3fb26
 	github.com/spf13/cast v1.7.1
 	github.com/stretchr/testify v1.10.0
 	gorm.io/driver/mysql v1.5.7

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/gookit/color v1.4.2/go.mod h1:fqRyamkC1W8uxl+lxCQxOT09l/vYfZ+QeiX3rKQ
 github.com/gookit/color v1.5.0/go.mod h1:43aQb+Zerm/BWh2GnrgOQm7ffz7tvQXEKV6BFMl7wAo=
 github.com/gookit/color v1.5.4 h1:FZmqs7XOyGgCAxmWyPslpiok1k05wmY3SJTytgvYFs0=
 github.com/gookit/color v1.5.4/go.mod h1:pZJOeOS8DM43rXbp4AZo1n9zCU2qjpcRko0b6/QJi9w=
-github.com/goravel/framework v1.15.2-0.20250309082515-9a7bcbec1a43 h1:XcdvbT/+48goVkCWfjhwcmpvSn8NVxKSvSlRIhKddgk=
-github.com/goravel/framework v1.15.2-0.20250309082515-9a7bcbec1a43/go.mod h1:WaPeuuviQKql/S8HSNk+ZK3xukJsw++h1G74CjbEnmk=
+github.com/goravel/framework v1.15.2-0.20250309092812-0d45fdd3fb26 h1:/Z6BtVCDoCdra+xW7FGIk4PFWli0vOiXryr37n2iI6Y=
+github.com/goravel/framework v1.15.2-0.20250309092812-0d45fdd3fb26/go.mod h1:WaPeuuviQKql/S8HSNk+ZK3xukJsw++h1G74CjbEnmk=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=

--- a/mysql.go
+++ b/mysql.go
@@ -93,7 +93,9 @@ func (r *Mysql) Gorm() (*gorm.DB, error) {
 }
 
 func (r *Mysql) Grammar() contractsdriver.Grammar {
-	return NewGrammar(r.config.Writes()[0].Database, r.config.Writes()[0].Prefix)
+	version, name := r.versionAndName()
+
+	return NewGrammar(r.config.Writes()[0].Database, r.config.Writes()[0].Prefix, version, name)
 }
 
 func (r *Mysql) Processor() contractsdriver.Processor {


### PR DESCRIPTION
## 📑 Description

https://github.com/goravel/goravel/issues/358

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->
This pull request includes multiple changes to the `grammar.go` and related files to add new fields and refactor methods for improved functionality. The most important changes include updating the `Grammar` struct, modifying methods to use new parameters, and updating tests to align with these changes.

### Updates to `Grammar` struct and methods:

* [`grammar.go`](diffhunk://#diff-077173eed4fe6bc9d3ea50005c9ad034d45bb24372cdc6aea57e61aab9f3afacR26-R40): Added `name` and `version` fields to the `Grammar` struct and updated the `NewGrammar` function to accept these new parameters.
* [`grammar.go`](diffhunk://#diff-077173eed4fe6bc9d3ea50005c9ad034d45bb24372cdc6aea57e61aab9f3afacL290-R298): Refactored `CompileRenameColumn` and `compileLegacyRenameColumn` methods to use the new `version` and `name` fields instead of fetching them from the `schema` parameter. [[1]](diffhunk://#diff-077173eed4fe6bc9d3ea50005c9ad034d45bb24372cdc6aea57e61aab9f3afacL290-R298) [[2]](diffhunk://#diff-077173eed4fe6bc9d3ea50005c9ad034d45bb24372cdc6aea57e61aab9f3afacL603-R606)
* [`grammar.go`](diffhunk://#diff-077173eed4fe6bc9d3ea50005c9ad034d45bb24372cdc6aea57e61aab9f3afacL306-R309): Modified `CompileRenameIndex` method to remove the `schema` parameter and use the new fields.

### Dependency updates:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L10-R10): Updated the version of `github.com/goravel/framework` from `v1.15.2-0.20250309082515-9a7bcbec1a43` to `v1.15.2-0.20250309092812-0d45fdd3fb26`.

### Test updates:

* [`grammar_test.go`](diffhunk://#diff-8bec341f2415d1a975ac79feb01a945838efe972da6b9253a259af476c76608dL25-R24): Updated the `TestCompileRenameColumn` test to remove mock objects for `schema` and `orm`, and to use the new `version` and `name` fields directly. [[1]](diffhunk://#diff-8bec341f2415d1a975ac79feb01a945838efe972da6b9253a259af476c76608dL25-R24) [[2]](diffhunk://#diff-8bec341f2415d1a975ac79feb01a945838efe972da6b9253a259af476c76608dL290-R312) [[3]](diffhunk://#diff-8bec341f2415d1a975ac79feb01a945838efe972da6b9253a259af476c76608dL332-L343)
* [`grammar_test.go`](diffhunk://#diff-8bec341f2415d1a975ac79feb01a945838efe972da6b9253a259af476c76608dL12): Removed unnecessary import of `mocksorm`.

### Additional changes:

* [`mysql.go`](diffhunk://#diff-1dcceb00f9e164c3494a982e1ed69ec5fd1506d1881b9cee030e9aee740cc378L96-R98): Updated the `Grammar` method to pass the `version` and `name` parameters when creating a new `Grammar` instance.
## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
