### PR TITLE
feat: [#474] goravel/minio should use the docker module of framework

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -2,12 +2,15 @@ package mysql
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	contractsdocker "github.com/goravel/framework/contracts/testing/docker"
 	"github.com/goravel/framework/support/color"
+	supportdocker "github.com/goravel/framework/support/docker"
 	"github.com/goravel/framework/support/process"
 	testingdocker "github.com/goravel/framework/testing/docker"
+	"github.com/spf13/cast"
 	"gorm.io/driver/mysql"
 	gormio "gorm.io/gorm"
 
@@ -54,8 +57,9 @@ func (r *Docker) Build() error {
 		return err
 	}
 
-	r.databaseConfig.ContainerID = r.imageDriver.Config().ContainerID
-	r.databaseConfig.Port = r.imageDriver.Config().ExposedPorts[r.databaseConfig.Port]
+	config := r.imageDriver.Config()
+	r.databaseConfig.ContainerID = config.ContainerID
+	r.databaseConfig.Port = cast.ToInt(supportdocker.ExposedPort(config.ExposedPorts, strconv.Itoa(r.databaseConfig.Port)))
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.4
 require (
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/Masterminds/squirrel v1.5.4
-	github.com/goravel/framework v1.15.2-0.20250609081116-6ecd2b376447
+	github.com/goravel/framework v1.15.2-0.20250609104359-90480ea9b358
 	github.com/spf13/cast v1.9.2
 	github.com/stretchr/testify v1.10.0
 	gorm.io/driver/mysql v1.5.7

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/gookit/validate v1.5.5 h1:jzMrwAYy9tbQa0mH8YFnv3C3JQR/0N4pRTsYiySwRJM
 github.com/gookit/validate v1.5.5/go.mod h1:p9sRPfpvYB4vXICBpEPzv8FoAky+XhUOhWQghgmmat4=
 github.com/goravel/file-rotatelogs/v2 v2.4.2 h1:g68AzbePXcm0V2CpUMc9j4qVzcDn7+7aoWSjZ51C0m4=
 github.com/goravel/file-rotatelogs/v2 v2.4.2/go.mod h1:23VuSW8cBS4ax5cmbV+5AaiLpq25b8UJ96IhbAkdo8I=
-github.com/goravel/framework v1.15.2-0.20250609081116-6ecd2b376447 h1:cDj3AvYAWnmdE96suMIP7m0BBkLPwtRyDS67GPvkq/w=
-github.com/goravel/framework v1.15.2-0.20250609081116-6ecd2b376447/go.mod h1:rMwbA0b1HX/2NUaPGxejp9AG4kfBfqy7D5gdRGy2clo=
+github.com/goravel/framework v1.15.2-0.20250609104359-90480ea9b358 h1:itDiQBc39teENLiTK7hQsKp7YGKjDvJ2KHlxMfyDeOg=
+github.com/goravel/framework v1.15.2-0.20250609104359-90480ea9b358/go.mod h1:rMwbA0b1HX/2NUaPGxejp9AG4kfBfqy7D5gdRGy2clo=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/474

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request includes updates to the `docker.go` file to improve how database container configurations are handled and a dependency update in `go.mod`. The most important changes involve refactoring the `Build` method in the `Docker` struct and upgrading the `goravel/framework` dependency.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
