### PR TITLE
fix: [#706] Setting timezone in MySQL DSN (e.g., Asia/Shanghai) causes “invalid DSN” error

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ import (
         "username": config.Env("DB_USERNAME", ""),
         "password": config.Env("DB_PASSWORD", ""),
         "charset":  "utf8mb4",
-        "loc":      "UTC", // Asia/Shanghai
         "prefix":   "",
         "singular": false,
         "via": func() (driver.Driver, error) {

--- a/config.go
+++ b/config.go
@@ -91,7 +91,11 @@ func (r *Config) fillDefault(configs []contracts.Config) []contracts.FullConfig 
 			fullConfig.Charset = r.config.GetString(fmt.Sprintf("database.connections.%s.charset", r.connection))
 		}
 		if fullConfig.Loc == "" {
-			fullConfig.Loc = r.config.GetString(fmt.Sprintf("database.connections.%s.loc", r.connection))
+			loc := r.config.GetString(fmt.Sprintf("database.connections.%s.loc", r.connection))
+			if loc == "" {
+				loc = r.config.GetString("app.timezone", "UTC")
+			}
+			fullConfig.Loc = loc
 		}
 		fullConfigs = append(fullConfigs, fullConfig)
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -255,6 +255,48 @@ func (s *ConfigTestSuite) TestFillDefault() {
 				},
 			},
 		},
+		{
+			name: "success with app.timezone",
+			configs: []contracts.Config{
+				{
+					Dsn:      dsn,
+					Host:     host,
+					Port:     port,
+					Database: database,
+					Username: username,
+					Password: password,
+				},
+			},
+			setup: func() {
+				s.mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.prefix", s.connection)).Return(prefix).Once()
+				s.mockConfig.EXPECT().GetBool(fmt.Sprintf("database.connections.%s.singular", s.connection)).Return(singular).Once()
+				s.mockConfig.EXPECT().GetBool(fmt.Sprintf("database.connections.%s.no_lower_case", s.connection)).Return(true).Once()
+				s.mockConfig.EXPECT().Get(fmt.Sprintf("database.connections.%s.name_replacer", s.connection)).Return(nameReplacer).Once()
+				s.mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.charset", s.connection)).Return(charset).Once()
+				s.mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.loc", s.connection)).Return("").Once()
+				s.mockConfig.EXPECT().GetString("app.timezone", "UTC").Return(loc).Once()
+			},
+			expectConfigs: []contracts.FullConfig{
+				{
+					Connection:   s.connection,
+					Driver:       Name,
+					Prefix:       prefix,
+					Singular:     singular,
+					Charset:      charset,
+					Loc:          loc,
+					NoLowerCase:  true,
+					NameReplacer: nameReplacer,
+					Config: contracts.Config{
+						Dsn:      dsn,
+						Database: database,
+						Host:     host,
+						Port:     port,
+						Username: username,
+						Password: password,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/mysql.go
+++ b/mysql.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/goravel/framework/contracts/config"
 	"github.com/goravel/framework/contracts/database"
@@ -130,7 +131,7 @@ func dsn(fullConfig contracts.FullConfig) string {
 	}
 
 	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=%s&parseTime=%t&loc=%s&multiStatements=true",
-		fullConfig.Username, fullConfig.Password, fullConfig.Host, fullConfig.Port, fullConfig.Database, fullConfig.Charset, true, fullConfig.Loc)
+		fullConfig.Username, fullConfig.Password, fullConfig.Host, fullConfig.Port, fullConfig.Database, fullConfig.Charset, true, url.QueryEscape(fullConfig.Loc))
 }
 
 func fullConfigToDialector(fullConfig contracts.FullConfig) gorm.Dialector {

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -43,3 +43,39 @@ func TestVersion(t *testing.T) {
 	assert.Contains(t, version, ".")
 	assert.NoError(t, docker.Shutdown())
 }
+
+// https://github.com/goravel/goravel/issues/706
+func TestIssue706(t *testing.T) {
+	t.Parallel()
+	writes := []contracts.FullConfig{
+		{
+			Config: contracts.Config{
+				Host:     "localhost",
+				Database: "goravel",
+				Username: "goravel",
+				Password: "Framework!123",
+			},
+			Loc:     "Asia/Shanghai",
+			Charset: "utf8mb4",
+		},
+	}
+
+	docker := NewDocker(nil, writes[0].Database, writes[0].Username, writes[0].Password)
+	assert.NoError(t, docker.Build())
+
+	writes[0].Config.Port = docker.databaseConfig.Port
+	_, err := docker.connect()
+	assert.NoError(t, err)
+
+	mockConfig := mocks.NewConfigBuilder(t)
+	mockConfig.EXPECT().Writers().Return(writes).Once()
+	mockConfig.EXPECT().Readers().Return([]contracts.FullConfig{}).Once()
+
+	mysql := &Mysql{
+		config: mockConfig,
+		log:    utils.NewTestLog(),
+	}
+	version := mysql.getVersion()
+	assert.Contains(t, version, ".")
+	assert.NoError(t, docker.Shutdown())
+}


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/706

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request introduces improvements to the handling of database connection configurations, including default timezone settings, URL encoding for connection strings, and new test cases to ensure robustness. It also includes minor updates to documentation and imports.

### Enhancements to database configuration:

* [`config.go`](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L94-R98): Updated the `fillDefault` method to use the `app.timezone` configuration as a fallback when no timezone (`loc`) is specified for database connections. This ensures a default value of "UTC" if neither is provided.
* [`mysql.go`](diffhunk://#diff-1dcceb00f9e164c3494a982e1ed69ec5fd1506d1881b9cee030e9aee740cc378L133-R134): Modified the `dsn` function to URL-encode the `loc` value in the connection string using `url.QueryEscape`, ensuring proper handling of special characters in timezones.

### Improvements to testing:

* [`config_test.go`](diffhunk://#diff-4bb821dfaef1884915ee03c5488bded04807301bc3f41fc7001a078c330ae980R258-R299): Added a new test case to `TestFillDefault` to verify that the `app.timezone` fallback is correctly applied when `database.connections.<connection>.loc` is empty.
* [`mysql_test.go`](diffhunk://#diff-83a20deeb58d42d0b2ff3c674d2817ca8f52ecf53876668c670ae03501c8a71bR46-R81): Introduced a new test, `TestIssue706`, to validate the handling of connection configurations with specific timezone settings (e.g., "Asia/Shanghai"). This test addresses issue #706 in the Goravel repository.

### Minor updates:

* [`mysql.go`](diffhunk://#diff-1dcceb00f9e164c3494a982e1ed69ec5fd1506d1881b9cee030e9aee740cc378R5): Added the `net/url` package import to support URL encoding for the `dsn` function.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L50): Removed the outdated comment referencing "Asia/Shanghai" in the default database configuration example.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
