### PR TITLE
feat: add UUID and ULID column type support to MySQL grammar

### DIFF
--- a/grammar.go
+++ b/grammar.go
@@ -699,10 +699,6 @@ func (r *Grammar) TypeUuid(_ driver.ColumnDefinition) string {
 	return "char(36)"
 }
 
-func (r *Grammar) TypeUlid(_ driver.ColumnDefinition) string {
-	return "char(26)"
-}
-
 func (r *Grammar) addModifiers(sql string, blueprint driver.Blueprint, column driver.ColumnDefinition) string {
 	for _, modifier := range r.modifiers {
 		sql += modifier(blueprint, column)

--- a/grammar.go
+++ b/grammar.go
@@ -695,6 +695,14 @@ func (r *Grammar) TypeTinyText(_ driver.ColumnDefinition) string {
 	return "tinytext"
 }
 
+func (r *Grammar) TypeUuid(_ driver.ColumnDefinition) string {
+	return "char(36)"
+}
+
+func (r *Grammar) TypeUlid(_ driver.ColumnDefinition) string {
+	return "char(26)"
+}
+
 func (r *Grammar) addModifiers(sql string, blueprint driver.Blueprint, column driver.ColumnDefinition) string {
 	for _, modifier := range r.modifiers {
 		sql += modifier(blueprint, column)

--- a/grammar_test.go
+++ b/grammar_test.go
@@ -791,6 +791,18 @@ func (s *GrammarSuite) TestTypeTimestamp() {
 	s.Equal("timestamp", s.grammar.TypeTimestamp(mockColumn))
 }
 
+func (s *GrammarSuite) TestTypeUuid() {
+	mockColumn := mocksdriver.NewColumnDefinition(s.T())
+
+	s.Equal("char(36)", s.grammar.TypeUuid(mockColumn))
+}
+
+func (s *GrammarSuite) TestTypeUlid() {
+	mockColumn := mocksdriver.NewColumnDefinition(s.T())
+
+	s.Equal("char(26)", s.grammar.TypeUlid(mockColumn))
+}
+
 func TestGetCommandByName(t *testing.T) {
 	commands := []*contractsdriver.Command{
 		{Name: "create"},

--- a/grammar_test.go
+++ b/grammar_test.go
@@ -797,12 +797,6 @@ func (s *GrammarSuite) TestTypeUuid() {
 	s.Equal("char(36)", s.grammar.TypeUuid(mockColumn))
 }
 
-func (s *GrammarSuite) TestTypeUlid() {
-	mockColumn := mocksdriver.NewColumnDefinition(s.T())
-
-	s.Equal("char(26)", s.grammar.TypeUlid(mockColumn))
-}
-
 func TestGetCommandByName(t *testing.T) {
 	commands := []*contractsdriver.Command{
 		{Name: "create"},


### PR DESCRIPTION
## 📑 Description

https://github.com/goravel/framework/pull/1114

This pull request adds support for two new column types, `UUID` and `ULID`, in the `Grammar` class, along with corresponding unit tests to ensure their correct implementation.

### New column type support:

* [`grammar.go`](diffhunk://#diff-077173eed4fe6bc9d3ea50005c9ad034d45bb24372cdc6aea57e61aab9f3afacR698-R705): Added methods `TypeUuid` and `TypeUlid` to the `Grammar` class, which return `char(36)` and `char(26)` respectively, to represent the `UUID` and `ULID` column types.

### Unit tests:

* [`grammar_test.go`](diffhunk://#diff-8bec341f2415d1a975ac79feb01a945838efe972da6b9253a259af476c76608dR794-R805): Added test methods `TestTypeUuid` and `TestTypeUlid` to verify that the `TypeUuid` and `TypeUlid` methods return the expected values (`char(36)` and `char(26)`) when invoked.

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
